### PR TITLE
fix multi-platform build

### DIFF
--- a/.github/workflows/call-docker-build-promote.yaml
+++ b/.github/workflows/call-docker-build-promote.yaml
@@ -33,6 +33,7 @@ jobs:
       dockerhub-enable: false
       ghcr-enable: true
       push: true
+      platforms: linux/amd64,linux/arm64
       image-names: |
         ghcr.io/${{ github.repository }}
 
@@ -40,7 +41,7 @@ jobs:
     name: CVE Scan
     if: github.event_name == 'pull_request'
     needs: docker-build-pr
-    permissions: 
+    permissions:
       packages: read
     uses: mostlydevops/actions/.github/workflows/reusable-trivy-scan-image.yaml@main
     secrets:
@@ -61,10 +62,11 @@ jobs:
       packages: write
       pull-requests: write
     uses: mostlydevops/actions/.github/workflows/reusable-docker-build.yaml@main
-    with:  
+    with:
       dockerhub-enable: false
       ghcr-enable: true
       push: true
+      platforms: linux/amd64,linux/arm64
       image-names: |
         ghcr.io/${{ github.repository }}
         ghcr.io/${{ github.repository }}-stable

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ RUN GOOS=linux GOARCH=$TARGETARCH go build dispatcher.go
 
 # RUN
 # defaults to using the target arch image
-FROM alpine
+FROM scratch as run
 
 EXPOSE 80
 CMD ["/dispatcher"]
 
-COPY --from=builder /go/dispatcher /
+COPY --from=builder /go/dispatcher /dispatcher
 COPY static /static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 # BUILD
-FROM golang:alpine as builder
+# use the build platforms matching arch rather than target arch
+FROM --platform=$BUILDPLATFORM golang:alpine as builder
+
+ARG TARGETARCH
 
 COPY dispatcher.go .
-RUN go build dispatcher.go
+# build for the target arch not the build platform host arch
+RUN GOOS=linux GOARCH=$TARGETARCH go build dispatcher.go
 
 # RUN
+# defaults to using the target arch image
 FROM alpine
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ FROM --platform=$BUILDPLATFORM golang:alpine as builder
 
 ARG TARGETARCH
 
+WORKDIR /go
+
 COPY dispatcher.go .
+
 # build for the target arch not the build platform host arch
 RUN GOOS=linux GOARCH=$TARGETARCH go build dispatcher.go
 
@@ -12,8 +15,9 @@ RUN GOOS=linux GOARCH=$TARGETARCH go build dispatcher.go
 # defaults to using the target arch image
 FROM scratch as run
 
-EXPOSE 80
-CMD ["/dispatcher"]
-
 COPY --from=builder /go/dispatcher /dispatcher
 COPY static /static/
+
+EXPOSE 80
+
+CMD ["/dispatcher"]


### PR DESCRIPTION
Ideally, we want golang to build without QEMU. This PR ensures:

1. the image we build on matches the host platform/architecture
2. the binary we build matches the target run platform
3. the final image we run from matches the architecture of the binary we built